### PR TITLE
Fix: Adjusted update user endpoint for hashed password

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,11 +129,12 @@ app.post("/users",
 
 //UPDATE User name
 app.put("/users/:Username", passport.authenticate('jwt', { session: false }), (req, res) => {
+    let hashedPassword = Users.hashPassword(req.body.Password);
     Users.findOneAndUpdate({ Username: req.params.Username }, {
         $set:
         {
             Username: req.body.Username,
-            Password: req.body.Password,
+            Password: hashedPassword,
             Email: req.body.Email,
             Birthdate: req.body.Birthdate
         }


### PR DESCRIPTION
Adjusted update user endpoint for hashed password, so that the password can be updated by the client. Password was not hashed on update meaning user could not login after changing password.